### PR TITLE
[template] remove extra leading slash

### DIFF
--- a/lib/template.ex
+++ b/lib/template.ex
@@ -40,7 +40,7 @@ defmodule SparkPost.Template do
     end
     body = %{substitution_data: substitution_data}
     :post
-    |> Endpoint.request("/templates/#{template.template_id}/preview#{qs}", body)
+    |> Endpoint.request("templates/#{template.template_id}/preview#{qs}", body)
     |> Endpoint.marshal_response(SparkPost.Content.Inline)
     |> SparkPost.Content.Inline.convert_from_field
   end


### PR DESCRIPTION
@ewandennis whoops, had an extra leading slash, which led Sparkpost to return 404s. FWIW, would be cool if the API could handle double slashes, though I understand why it doesn't.